### PR TITLE
no longer need to specify url when instantiating client

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Add this dependency to your project's POM:
 ## Usage
 
 ```java
-RavenApiClient ravenApiClient = new RavenApiClient("api.ravenapp.dev", Authorization.of("AuthKey <auth>"));
+RavenApiClient ravenApiClient = new RavenApiClient(Authorization.of("AuthKey <auth>"));
 try {
     var response = client.send(Send.Request.builder()
                 .appId("<app_id>")

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ API documentation is available at <https://docs.ravenapp.dev/introduction>.
 Add this dependency to your project's build file:
 
 ```groovy
-implementation "dev.ravenapp:raven-java:0.0.24"
+implementation "dev.ravenapp:raven-java:0.0.32"
 ```
 
 ### Maven users
@@ -25,7 +25,7 @@ Add this dependency to your project's POM:
 <dependency>
   <groupId>dev.ravenapp</groupId>
   <artifactId>raven-java</artifactId>
-  <version>0.0.31</version>
+  <version>0.0.32</version>
 </dependency>
 ```
 

--- a/sample-app/src/main/java/sample/App.java
+++ b/sample-app/src/main/java/sample/App.java
@@ -12,8 +12,7 @@ public final class App {
       String authKey = System.getenv("RAVEN_TOKEN");
       Authorization auth = Authorization.of(authKey);
 
-      RavenApiClient ravenApiClient =
-                new RavenApiClient("api.ravenapp.dev", auth);
+      RavenApiClient ravenApiClient = new RavenApiClient(auth);
 
       try {
           Device device = ravenApiClient.device().add(Add.Request.builder()

--- a/src/main/java/com/raven/api/RavenApiClient.java
+++ b/src/main/java/com/raven/api/RavenApiClient.java
@@ -9,6 +9,7 @@ import com.raven.api.client.event.exceptions.SendBulkException;
 import com.raven.api.client.event.exceptions.SendException;
 import com.raven.api.client.event.types.SendEventResponse;
 import com.raven.api.client.user.UserServiceClient;
+import com.raven.api.core.Environment;
 import java.lang.String;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
@@ -21,16 +22,14 @@ public final class RavenApiClient {
 
   private final Supplier<UserServiceClient> userServiceClient;
 
-  public RavenApiClient(String url) {
-    this.userServiceClient = memoize(() -> new UserServiceClient(url));
-    this.eventServiceClient = memoize(() -> new EventServiceClient(url));
-    this.deviceServiceClient = memoize(() -> new DeviceServiceClient(url));
+  public RavenApiClient(Authorization auth) {
+    this(Environment.PROD, auth);
   }
 
-  public RavenApiClient(String url, Authorization auth) {
-    this.userServiceClient = memoize(() -> new UserServiceClient(url, auth));
-    this.eventServiceClient = memoize(() -> new EventServiceClient(url, auth));
-    this.deviceServiceClient = memoize(() -> new DeviceServiceClient(url, auth));
+  public RavenApiClient(Environment environment, Authorization auth) {
+    this.userServiceClient = memoize(() -> new UserServiceClient(environment.getUrl(), auth));
+    this.eventServiceClient = memoize(() -> new EventServiceClient(environment.getUrl(), auth));
+    this.deviceServiceClient = memoize(() -> new DeviceServiceClient(environment.getUrl(), auth));
   }
 
   public final DeviceServiceClient device() {


### PR DESCRIPTION
because `RavenApiClient.java` is in the `.fernignore` we need to manually update this file. 